### PR TITLE
Fix #290: actually have sly-switch-to-most-recent use prefix arg

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -2749,7 +2749,7 @@ Debugged requests are ignored."
   "Switch to most recent buffer in MODE, a major-mode symbol.
 With prefix argument, prompt for MODE"
   (interactive
-   (list (if prefix-arg
+   (list (if current-prefix-arg
              (intern (sly-completing-read
                       "Switch to most recent buffer in what mode? "
                       (mapcar #'symbol-name '(lisp-mode


### PR DESCRIPTION
* sly.el (sly-switch-to-most-recent): change prefix-arg to
current-prefix-arg, since the former does not store anything.